### PR TITLE
[#17348][MIG] project_task_material_stock: assigning analytic.line em…

### DIFF
--- a/project_task_material_stock/models/project_task.py
+++ b/project_task_material_stock/models/project_task.py
@@ -232,7 +232,7 @@ class ProjectTaskMaterial(models.Model):
         if "employee_id" in self.env["account.analytic.line"]._fields:
             vals["employee_id"] = (
                 self.env["hr.employee"]
-                .search([("user_id", "=", self.task_id.user_id.id)], limit=1)
+                .search([("user_id", "=", self.task_id.manager_id.id)], limit=1)
                 .id
             )
         res.update(vals)


### PR DESCRIPTION
…ployee to the project manager instead of user_id to the project.task. Because we don't have user_id field in project.task (we have user_ids))